### PR TITLE
Add q.unit convenience class

### DIFF
--- a/PhysicalQuantities/Unit.py
+++ b/PhysicalQuantities/Unit.py
@@ -63,7 +63,7 @@ def isphysicalunit(x):
     :param x: unit
     :type x: PhysicalUnit
     """
-    return hasattr(x, 'factor') and hasattr(x, 'powers')
+    return isinstance(x, PhysicalUnit)
 
 
 class PhysicalUnit:

--- a/PhysicalQuantities/__init__.py
+++ b/PhysicalQuantities/__init__.py
@@ -103,3 +103,34 @@ def linspace(start, stop, num = 50,  endpoint=True, retstep=False):
         return PhysicalQuantity(array[0], unit), PhysicalQuantity(array[1], unit)
     else:
         return array * PhysicalQuantity(1, unit)
+
+        
+from PhysicalQuantities import PhysicalQuantity, unit_table
+from PhysicalQuantities.dBQuantity import dBQuantity, dB_units, isdbquantity
+from PhysicalQuantities.Unit import isphysicalunit
+
+class _q:
+    def __init__(self):
+        self.table = {}
+        for key in dB_units:
+            self.table[key] = dBQuantity(1, key)
+        for key in unit_table:
+            self.table[key] = unit_table[key] # for some reason directly using a PhysicalQuantity bombs
+            
+    def __dir__(self):
+        return self.table.keys
+    
+    def __getattr__(self, attr):
+        try:
+            Q = self.table[attr]
+        except:
+            raise AttributeError('Unit %s not found' % Q)
+        if isphysicalunit(Q):
+            return PhysicalQuantity(1, Q)
+        elif isdbquantity(Q):
+            return Q
+        else:
+            raise AttributeError('Unknown unit %s' % attr)
+            
+
+q = _q()

--- a/PhysicalQuantities/dBQuantity.py
+++ b/PhysicalQuantities/dBQuantity.py
@@ -67,11 +67,19 @@ def dB(x):
 
 
 def dB10(x):
-    return dBQuantity(10*np.log10(x),'dB',islog=True, factor=10)
+    if isinstance(x, PhysicalQuantity):
+        val = x.base.value
+    else:
+        val = x
+    return dBQuantity(10*np.log10(val),'dB',islog=True, factor=10)
 
 
 def dB20(x):
-    return dBQuantity(20*np.log10(x),'dB',islog=True, factor=20)
+    if isinstance(x, PhysicalQuantity):
+        val = x.base.value
+    else:
+        val = x
+    return dBQuantity(20*np.log10(val),'dB',islog=True, factor=20)
 
 
 def isdbquantity(q):
@@ -261,8 +269,8 @@ class dBQuantity:
     __rsub__ = __sub__
     
     def __mul__(self, other):
-        if self.unit is 'dB' and not hasattr(other,'unit'):
-            # dB without physical dimension can be multiplied with a factor
+        if  not hasattr(other,'unit'):
+            # dB values will be multiplied with a factor to enable "a = 2 * q.dBm"
             value = self.value * other
             return self.__class__(value, self.unit, islog=True)
 
@@ -276,6 +284,9 @@ class dBQuantity:
 
     __rdiv__ = __div__
 
+    def __neg__(self):
+        return self.__class__(-self.value, self.unit, islog=True)
+    
     def __float__(self):
         # return linear value in base unit
         dbw = self.value + dB_units[self.unit][1]


### PR DESCRIPTION
q.<unit> can now be used to say e.g. 1*q.mm or 2*q.dBm