### PR TITLE
Add bitwise ufuncs to fix test using assert_almost_equal

### DIFF
--- a/PhysicalQuantities/quantityarray.py
+++ b/PhysicalQuantities/quantityarray.py
@@ -65,6 +65,11 @@ class PhysicalQuantityArray(ndarray):
             else:
                 args.append(par2)
                 out_unit = out_unit ** par2
+        elif op in ['bitwise_or', 'bitwise_and', 'bitwise_xir']:
+            args = []
+            for par in inputs:
+                args.append(par.view(np.ndarray))
+            kwargs=dict(out=self.view(np.ndarray))
         else:
             args = []
             for par2 in inputs:

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -51,28 +51,28 @@ def test_getattr():
     a = np.random.randn(10)
     b = QA(a, 'm')
     c = b.m
-    assert_almost_equal(b, c)
+    assert_almost_equal(b._, c._)
 
 
 def test_getattr_dropunit():
     a = np.random.randn(10)
     b = QA(a, 'm')
     c = b.m_
-    assert_almost_equal(b, c)
+    assert_almost_equal(b._, c)
 
 
 def test_base():
     a = np.random.randn(10)
     b = QA(a, 'm')
     c = b.base
-    assert_almost_equal(b, c)
+    assert_almost_equal(b._, c._)
 
 
 def test_base_2():
     a = np.random.randn(10)
     b = QA(a, 'm/s')
     c = b.base
-    assert_almost_equal(b, c)
+    assert_almost_equal(b._, c._)
 
 
 def test_repr():
@@ -85,7 +85,7 @@ def test_add_same_units():
     a = np.random.randn(10)
     b = QA(a, 'm')
     c = b+b
-    assert_almost_equal((b+b).view(np.ndarray), a+a)
+    assert_almost_equal(c, a+a)
     assert c.unit == b.unit
 
 
@@ -100,7 +100,7 @@ def test_add_different_units():
 def test_subtract_same_units():
     a = QA(np.random.randn(10), 'm')
     b = QA(np.random.randn(10), 'm')
-    assert_almost_equal((a-b).view(np.ndarray), a+b)
+    assert_almost_equal((a-b)._, a._-b._)
     assert a.unit == b.unit
 
 
@@ -116,18 +116,18 @@ def test_multiply_different_units():
     b = QA(np.random.randn(10), 's')
     c = a*b
     assert str(c.unit) == 'm*s'
-    assert_almost_equal(c, a.view(np.ndarray)*b.view(np.ndarray))
+    assert_almost_equal(c, a*b)
 
 
 def test_square():
     a = QA(np.random.randn(10), 'm')
     b = a**2
-    assert_almost_equal(b, a.view(np.ndarray)**2)
+    assert_almost_equal(b, a**2)
     assert str(b.unit) == 'm^2'
 
 
 def test_power():
     a = QA(np.random.randn(10), 'm')
     b = a**3
-    assert_almost_equal(b, a.view(np.ndarray)**3)
+    assert_almost_equal(b, a**3)
     assert str(b.unit) == 'm^3'

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -4,10 +4,10 @@ from PhysicalQuantities import unit_table
 
 if __version__ < '7.0.0':
     from PhysicalQuantities.ipython import transform_legacy
-    test_transformer = transform_legacy().func
+    _test_transformer = transform_legacy().func
 else:
     from PhysicalQuantities.ipython import transform_line
-    test_transformer = transform_line
+    _test_transformer = transform_line
 
 units_list = list(unit_table.keys())
 
@@ -15,54 +15,54 @@ units_list = list(unit_table.keys())
 def test_simple():
     """ No transformation """
     line = 'a =0'
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert line == ret
 
 
 def test_1():
     """ Simple unit """
     line = '1V'
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert ret == "(1 *pq.V)"
 
 
 def test_6():
     """ Don't convert strings"""
     line = "'1V'"
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert ret == "'1V'"
 
 
 def test_7():
     line = '1V-2V'
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert ret == "(1 *pq.V) -(2 *pq.V)"
 
 
 def test_8():
     """Divide unit quantities"""
     line = '1V/2m'
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert ret == "(1 *pq.V) /(2 *pq.m)"
 
 
 def test_9():
     """Combined dimension"""
     line = '1m/s'
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert ret == "(1 *pq.m) / pq.s"
 
 
 def test_10():
     """Test exponentials"""
     line = '10m**2'
-    ret = test_transformer(line).strip()
+    ret = _test_transformer(line).strip()
     assert ret == 'PhysicalQuantity(10 ,"m**2")'
 
 
 def test_multiline_comment():
     """Make sure multiline comments are handled properly"""
     lines = '"""\n2m"""'
-    ret = test_transformer(lines).strip()
+    ret = _test_transformer(lines).strip()
     assert ret == lines
 


### PR DESCRIPTION
`assert_alsmost_equal` will quietly fail without raising an error on assert.