### PR TITLE
fix problem with sr prefixrange and extend unittest to catch regression

### DIFF
--- a/PhysicalQuantities/default_units.py
+++ b/PhysicalQuantities/default_units.py
@@ -23,10 +23,10 @@ addprefixed('K', prefixrange='engineering')
 addprefixed('mol', prefixrange='engineering')
 addprefixed('cd', prefixrange='engineering')
 addprefixed('rad', prefixrange='engineering')
-addprefixed('sr', 'prefixrange=engineering')
+addprefixed('sr', prefixrange='engineering')
 
 addprefixed(add_composite_unit('Hz', 1, '1/s', verbosename='Hertz',
-                               url='https://en.wikipedia.org/wiki/Hertz'), 'engineering')
+                               url='https://en.wikipedia.org/wiki/Hertz'), prefixrange='engineering')
 addprefixed(add_composite_unit('N', 1, 'm*kg/s**2', verbosename='Newton',
                                url='https://en.wikipedia.org/wiki/Newton_(unit)'), prefixrange='engineering')
 addprefixed(add_composite_unit('Pa', 1, 'N/m**2', verbosename='Pascal',

--- a/tests/test_extended_prefixed.py
+++ b/tests/test_extended_prefixed.py
@@ -2,10 +2,22 @@ from pytest import raises
 from PhysicalQuantities import q
 
 
-def test_m():
+def test_extend_prefixes():
     """Check if extended prefixes get added to q.m"""
     assert q.m == q.m
+    assert q.sr == q.sr
+    assert q.Hz == q.Hz
+
     with raises(KeyError):
         assert q.Ym == q.Ym
+
+    with raises(KeyError):
+        assert q.Ysr == q.Ysr
+
+    with raises(KeyError):        
+        assert q.YHz == q.YHz
+    
     import PhysicalQuantities.extend_prefixed
     assert q.Ym == q.Ym
+    assert q.Ysr == q.Ysr
+    assert q.YHz == q.YHz


### PR DESCRIPTION
Nice project! 

Noticed a typo for 'sr' while browsing through the code.

Hz works fine, just made it similar to the other composite units.